### PR TITLE
Add fail-on-error input

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ code review experience.
 Optional. Report level for reviewdog [`info`, `warning`, `error`].
 The default is `error`.
 
+### `fail_on_error`
+
+Optional. Exit code 1 for reviewdog if it finds errors [`true`, `false`].
+The default is `false`.
+
 ### `reporter`
 
 Optional. Reporter of reviewdog command [`github-pr-check`, `github-check`, `github-pr-review`].

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,9 @@ inputs:
   level:
     description: 'Report level for reviewdog [info,warning,error]'
     default: 'error'
+  fail_on_error:
+    description: 'Exit code 1 for reviewdog if it finds errors [true,false]'
+    default: 'false'
   reporter:
     description: |
       Reporter of reviewdog command [github-pr-check,github-check,github-pr-review].
@@ -29,6 +32,7 @@ runs:
       env:
         INPUT_GITHUB_TOKEN: ${{ inputs.github_token }}
         INPUT_LEVEL: ${{ inputs.level }}
+        INPUT_FAIL_ON_ERROR: ${{ inputs.fail_on_error }}
         INPUT_REPORTER: ${{ inputs.reporter }}
         INPUT_FILTER_MODE: ${{ inputs.filter_mode }}
         INPUT_USE_BUNDLER: ${{ inputs.use_bundler }}

--- a/script.sh
+++ b/script.sh
@@ -26,5 +26,6 @@ ${BUNDLE_EXEC}erblint --lint-all --format compact \
       -efm="%f:%l:%c: %m" \
       -reporter="${INPUT_REPORTER}" \
       -filter-mode="${INPUT_FILTER_MODE}" \
-      -level="${INPUT_LEVEL}"
+      -level="${INPUT_LEVEL}" \
+      -fail-on-error="${INPUT_FAIL_ON_ERROR}"
 echo '::endgroup::'


### PR DESCRIPTION
Hello!

This adds an input to set the fail-on-error flag for reviewdog. Thank you for making this action, it is very useful.

Demonstration:  
Flag on, check fails: https://github.com/brianjaustin/otwarchive/pull/1/commits/cbb4785f93b2db8d4d539c317baa40becfbd28af  
Flag off, check succeeds: https://github.com/brianjaustin/otwarchive/pull/1/commits/15dae52da806cd6a7e0712fabd7730f3ff18abab