### PR TITLE
Replace deprecated fail-on-error flag with fail-level

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ code review experience.
 Optional. Report level for reviewdog [`info`, `warning`, `error`].
 The default is `error`.
 
-### `fail_on_error`
+### `fail_level`
 
-Optional. Exit code 1 for reviewdog if it finds errors [`true`, `false`].
-The default is `false`.
+Optional. Exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level [`none`, `any`, `info`, `warning`, `error`].
+The default is `none`.
 
 ### `reporter`
 

--- a/action.yml
+++ b/action.yml
@@ -8,9 +8,11 @@ inputs:
   level:
     description: 'Report level for reviewdog [info,warning,error]'
     default: 'error'
-  fail_on_error:
-    description: 'Exit code 1 for reviewdog if it finds errors [true,false]'
-    default: 'false'
+  fail_level:
+    description: |
+      Exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level [none,any,info,warning,error].
+      Default is none.
+    default: 'none'
   reporter:
     description: |
       Reporter of reviewdog command [github-pr-check,github-check,github-pr-review].
@@ -32,7 +34,7 @@ runs:
       env:
         INPUT_GITHUB_TOKEN: ${{ inputs.github_token }}
         INPUT_LEVEL: ${{ inputs.level }}
-        INPUT_FAIL_ON_ERROR: ${{ inputs.fail_on_error }}
+        INPUT_FAIL_LEVEL: ${{ inputs.fail_level }}
         INPUT_REPORTER: ${{ inputs.reporter }}
         INPUT_FILTER_MODE: ${{ inputs.filter_mode }}
         INPUT_USE_BUNDLER: ${{ inputs.use_bundler }}

--- a/script.sh
+++ b/script.sh
@@ -27,5 +27,5 @@ ${BUNDLE_EXEC}erblint --lint-all --format compact \
       -reporter="${INPUT_REPORTER}" \
       -filter-mode="${INPUT_FILTER_MODE}" \
       -level="${INPUT_LEVEL}" \
-      -fail-on-error="${INPUT_FAIL_ON_ERROR}"
+      -fail-level="${INPUT_FAIL_LEVEL}"
 echo '::endgroup::'


### PR DESCRIPTION
To adapt for the same change in the reviewdog 0.20.2, see https://github.com/reviewdog/reviewdog/pull/1854.