### PR TITLE
Add support for custom tool names

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ Optional. Do not install Rubocop or its extensions. Default: `false`.
 
 Optional. Run Rubocop with bundle exec. Default: `false`.
 
+### `tool_name`
+
+Optional. Tool name to be displayed in the reviewdog comment.
+Useful when you have multiple linters running in a single workflow.
+Default: `erb-lint`.
+
 ## Example usage
 
 ```yml

--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,9 @@ inputs:
       Config file to pass to erb-lint.
       Default is .erb-lint.yml.
     default: '.erb-lint.yml'
+  tool_name:
+    description: 'Tool name to be displayed in the reviewdog comment. Default: `erb-lint`'
+    default: 'erb-lint'
 
 runs:
   using: 'composite'
@@ -53,6 +56,7 @@ runs:
         INPUT_FILTER_MODE: ${{ inputs.filter_mode }}
         INPUT_USE_BUNDLER: ${{ inputs.use_bundler }}
         INPUT_CONFIG_FILE: ${{ inputs.config_file }}
+        INPUT_TOOL_NAME: ${{ inputs.tool_name }}
 branding:
   icon: check-circle
   color: blue

--- a/script.sh
+++ b/script.sh
@@ -26,6 +26,12 @@ else
   CONFIG_FILE="--config=${INPUT_CONFIG_FILE}"
 fi
 
+if [ -z "${INPUT_TOOL_NAME}" ]; then
+  TOOL_NAME="erb-lint"
+else
+  TOOL_NAME="${INPUT_TOOL_NAME}"
+fi
+
 echo '::group:: Running erb-lint with reviewdog 🐶 ...'
 ${BUNDLE_EXEC}erblint --lint-all --format compact ${CONFIG_FILE} \
   | reviewdog \
@@ -33,6 +39,7 @@ ${BUNDLE_EXEC}erblint --lint-all --format compact ${CONFIG_FILE} \
       -reporter="${INPUT_REPORTER}" \
       -filter-mode="${INPUT_FILTER_MODE}" \
       -level="${INPUT_LEVEL}" \
+      -name="${TOOL_NAME}" \
       -fail-level="${INPUT_FAIL_LEVEL}" \
       -fail-on-error="${INPUT_FAIL_ON_ERROR}"
 echo '::endgroup::'


### PR DESCRIPTION
Since https://github.com/reviewdog/reviewdog/pull/1804, If you run multiple instances of this action there is a risk PR comments created by one are deleted by another. By providing a different name, we should not see this happen