### PR TITLE
fix config file default to be .erb_lint.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,8 +36,8 @@ inputs:
   config_file:
     description: |
       Config file to pass to erb-lint.
-      Default is .erb-lint.yml.
-    default: '.erb-lint.yml'
+      Default is .erb_lint.yml.
+    default: '.erb_lint.yml'
 
 runs:
   using: 'composite'

--- a/script.sh
+++ b/script.sh
@@ -21,7 +21,7 @@ else
 fi
 
 if [ -z "${INPUT_CONFIG_FILE}" ]; then
-  CONFIG_FILE="--config=.erb-lint.yml"
+  CONFIG_FILE="--config=.erb_lint.yml"
 else
   CONFIG_FILE="--config=${INPUT_CONFIG_FILE}"
 fi


### PR DESCRIPTION
It is the default by the tool:
```
        --config FILENAME            Config file [default: .erb_lint.yml]
```