### PR TITLE
use underscored tool name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# GitHub Action: Run erb-lint with reviewdog 🐶
+# GitHub Action: Run erb_lint with reviewdog 🐶
 
-This action runs [erb-lint](https://github.com/Shopify/erb-lint) with
+This action runs [erb_lint](https://github.com/Shopify/erb_lint) with
 [reviewdog](https://github.com/reviewdog/reviewdog) on pull requests to improve
 code review experience.
 

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
-name: 'Run erb-lint with reviewdog'
-description: '🐶 Run erb-lint with reviewdog on pull requests to improve code review experience.'
+name: 'Run erb_lint with reviewdog'
+description: '🐶 Run erb_lint with reviewdog on pull requests to improve code review experience.'
 author: 'tk0miya'
 inputs:
   github_token:
@@ -31,11 +31,11 @@ inputs:
       Default is added.
     default: 'added'
   use_bundler:
-    description: "Run erb-lint with bundle exec. Default: `false`"
+    description: "Run erb_lint with bundle exec. Default: `false`"
     default: 'false'
   config_file:
     description: |
-      Config file to pass to erb-lint.
+      Config file to pass to erb_lint.
       Default is .erb_lint.yml.
     default: '.erb_lint.yml'
 

--- a/script.sh
+++ b/script.sh
@@ -12,7 +12,7 @@ curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.s
 echo '::endgroup::'
 
 if [ "${INPUT_USE_BUNDLER}" = "true" ]; then
-  echo '::group:: Installing erb-lint via bundler'
+  echo '::group:: Installing erb_lint via bundler'
   bundle install
   echo '::endgroup::'
 fi
@@ -29,8 +29,8 @@ else
   CONFIG_FILE="--config=${INPUT_CONFIG_FILE}"
 fi
 
-echo '::group:: Running erb-lint with reviewdog 🐶 ...'
-${BUNDLE_EXEC}erblint \
+echo '::group:: Running erb_lint with reviewdog 🐶 ...'
+${BUNDLE_EXEC}erb_lint \
   --lint-all \
   --format compact \
   --fail-level F \


### PR DESCRIPTION
```
Calling `erblint` is deprecated, please call the renamed executable `erb_lint` instead.
```