### PR TITLE
use bash with pipefail to not allow errors in pipe to be ignored

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -1,4 +1,7 @@
-#!/bin/sh -e
+#!/usr/bin/env bash
+
+set -euo pipefail
+
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
 TEMP_PATH="$(mktemp -d)"

--- a/script.sh
+++ b/script.sh
@@ -30,7 +30,10 @@ else
 fi
 
 echo '::group:: Running erb-lint with reviewdog 🐶 ...'
-${BUNDLE_EXEC}erblint --lint-all --format compact ${CONFIG_FILE} \
+${BUNDLE_EXEC}erblint \
+  --lint-all \
+  --format compact \
+  ${CONFIG_FILE} \
   | reviewdog \
       -efm="%f:%l:%c: %m" \
       -reporter="${INPUT_REPORTER}" \

--- a/script.sh
+++ b/script.sh
@@ -33,6 +33,7 @@ echo '::group:: Running erb-lint with reviewdog 🐶 ...'
 ${BUNDLE_EXEC}erblint \
   --lint-all \
   --format compact \
+  --fail-level F \
   ${CONFIG_FILE} \
   | reviewdog \
       -efm="%f:%l:%c: %m" \


### PR DESCRIPTION
Prevent errors running erblint in `erblint … | reviewdog …` to be ignored/invisible.
This also required adding `--fail-level error` to allow reviewdog setting to determine action failure, but still fail the action if erb_lint fails to run