### PR TITLE
set name for reviewdog

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -37,6 +37,7 @@ ${BUNDLE_EXEC}erblint \
   ${CONFIG_FILE} \
   | reviewdog \
       -efm="%f:%l:%c: %m" \
+      -name=erb_lint \
       -reporter="${INPUT_REPORTER}" \
       -filter-mode="${INPUT_FILTER_MODE}" \
       -level="${INPUT_LEVEL}" \


### PR DESCRIPTION
Otherwise report is listed under `reviewdog`

Simplified version of #5